### PR TITLE
Remove trailing slashes on orders and positions

### DIFF
--- a/bitfinex.coffee
+++ b/bitfinex.coffee
@@ -140,11 +140,11 @@ module.exports = class Bitfinex
 
 	active_orders: (cb) ->
 
-		@make_request('orders/', {}, cb)  
+		@make_request('orders', {}, cb)  
 
 	active_positions: (cb) ->
 
-		@make_request('positions/', {}, cb)  
+		@make_request('positions', {}, cb)  
 
 	past_trades: (symbol, timestamp, limit_trades, cb) ->
 


### PR DESCRIPTION
The trailing slashes were causing an error {"message": "Must specify a 'request' field in the payload that matches the URL path."}
