### PR TITLE
Millisecond level nonce

### DIFF
--- a/src/bitfinex.coffee
+++ b/src/bitfinex.coffee
@@ -14,7 +14,7 @@ module.exports = class Bitfinex
 		@version = 'v1'
 		@key = key
 		@secret = secret
-		@nonce = Math.ceil((new Date()).getTime() / 1000)
+		@nonce = new Date().getTime()
 
 	_nonce: () ->
 


### PR DESCRIPTION
Bitfinex seems to support milisecond-level nonce.

This is simpler to generate and will likely avoid many "nonce too small" type errors.
