### PR TITLE
Update packages with CVEs

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,14 +3,12 @@
   "version": "1.0.3",
   "gypfile": true,
   "scripts": {
-    "start": "node test.js"
+    "build": "coffee --bare --compile *.coffee",
+    "prepublish": "coffee --output lib --compile src",
+    "scan_packages": "nsp check --output summary"
   },
   "description": "node.js wrapper for bitfinex cryptocurrency exchange",
   "main": "lib/bitfinex.js",
-  "scripts": {
-     "build": "coffee --bare --compile *.coffee",
-     "prepublish": "coffee --output lib --compile src"
-  },
   "keywords": [
     "bitfinex",
     "litecoin",
@@ -20,13 +18,18 @@
   ],
   "author": {
     "name": "Gabriel Ferrin",
-    "email": "garf11235813@gmail.com"},
+    "email": "garf11235813@gmail.com"
+  },
   "contributors": "Nick Addison",
   "dependencies": {
-    "request": "~2.30.0"
+    "coffee-script": "^1.10.0",
+    "request": "2.74.0"
   },
   "repository": {
     "type": "git",
     "url": "git://github.com/gferrin/bitfinex.git"
+  },
+  "devDependencies": {
+    "nsp": "^2.6.1"
   }
 }


### PR DESCRIPTION
The request package in this node module has CVEs. This PR will update
it.

Output of `$ nsp check --output summary`

```
(+) 4 vulnerabilities found
 Name           Installed   Patched                      Path                                                    More Info
 qs             0.6.6       >= 1.x                       bitfinex@1.0.3 > request@2.30.0 > qs@0.6.6              https://nodesecurity.io/advisories/28
 qs             0.6.6       >= 1.x                       bitfinex@1.0.3 > request@2.30.0 > qs@0.6.6              https://nodesecurity.io/advisories/29
 hawk           1.0.0       >=3.1.3 < 4.0.0 || >=4.1.1   bitfinex@1.0.3 > request@2.30.0 > hawk@1.0.0            https://nodesecurity.io/advisories/77
 tough-cookie   0.9.15      >=2.3.0                      bitfinex@1.0.3 > request@2.30.0 > tough-cookie@0.9.15   https://nodesecurity.io/advisories/130
```

Also had to include in the `package.json` file the dependency on
coffee-scipt since it was missing.
